### PR TITLE
Refactored to prevent syntax error

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -41,16 +41,16 @@ this.addEventListener('install', function(event) {
 // )};
 
 this.addEventListener('fetch', function(event) {
-  event.respondWith(
-    caches.match(event.request).catch(function() {
-      return event.default().then(function(response) {
-        caches.get('v1').then(function(cache) {
-          cache.put(event.request, response.clone());
-          return response;
-        });  
-      });
-    }).catch(function() {
-     return caches.match('/sw-test/gallery/myLittleVader.jpg');
+  var cachedResponse = caches.match(event.request).catch(function() {
+    return event.default().then(function(response) {
+      caches.get('v1').then(function(cache) {
+        cache.put(event.request, response.clone());
+        return response;
+      });  
     });
-  );
+  }).catch(function() {
+    return caches.match('/sw-test/gallery/myLittleVader.jpg');
+  });
+    
+  event.respondWith(cachedResponse);
 });


### PR DESCRIPTION
After four commits (one by mine) trying to fix this is better to refactor it. Here I removed the the argument outside the function call in a variable.
