### PR TITLE
Pass array to cache.addAll

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 this.addEventListener('install', function(event) {
   event.waitUntil(
     caches.open('v1').then(function(cache) {
-      return cache.addAll(
+      return cache.addAll([
         '/sw-test/',
         '/sw-test/index.html',
         '/sw-test/style.css',
@@ -12,7 +12,7 @@ this.addEventListener('install', function(event) {
         '/sw-test/gallery/bountyHunters.jpg',
         '/sw-test/gallery/myLittleVader.jpg',
         '/sw-test/gallery/snowTroopers.jpg'
-      );
+      ]);
     })
   );
 });


### PR DESCRIPTION
I initially got an error when using the original source, but with this change to passing an array seemed to fix it, and the doc for addAll indicates it should be an array (change tested in today's Nightly)