### PR TITLE
Call e.respondWith() in fetch event handler.

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -19,15 +19,15 @@ this.addEventListener('install', function(event) {
 
 this.addEventListener('fetch', function(event) {
   var response;
-  var cachedResponse = caches.match(event.request).catch(function() {
+  event.respondWith(caches.match(event.request).catch(function() {
     return fetch(event.request);
   }).then(function(r) {
     response = r;
     caches.open('v1').then(function(cache) {
       cache.put(event.request, response);
-    });  
+    });
     return response.clone();
   }).catch(function() {
     return caches.match('/sw-test/gallery/myLittleVader.jpg');
-  });
+  }));
 });


### PR DESCRIPTION
Currently the fetch event handler incorrectly returns a promise from the fetch event handler.  This will have no effect and result in the original network request being performed.  Instead, we must pass the promise to e.respondWith() to properly intercept the request.