### PR TITLE
Fix #11: Do not add /sw-test/gallery/ to Cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,6 @@ this.addEventListener('install', function(event) {
         '/sw-test/app.js',
         '/sw-test/image-list.js',
         '/sw-test/star-wars-logo.jpg',
-        '/sw-test/gallery/',
         '/sw-test/gallery/bountyHunters.jpg',
         '/sw-test/gallery/myLittleVader.jpg',
         '/sw-test/gallery/snowTroopers.jpg'


### PR DESCRIPTION
"/sw-test/gallery/" is a 404, cache.addAll throws an exception when trying to cache this request. 
Service worker installations fails because of this on Firefox.

Fixes Issue #11 .