### PR TITLE
Fixing https typo in example links in README.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # sw-test
-Service Worker test repository. This is a very simple demo to show basic service worker features in action. The demo can be seen on [our GitHub pages](http://mdn.github.io/sw-test/).
+Service Worker test repository. This is a very simple demo to show basic service worker features in action. The demo can be seen on [our GitHub pages](https://mdn.github.io/sw-test/).
 
 You can find a lot more out about how this works by reading [Using Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers). In particular, read [Why is my service worker failing to register?](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#Why_is_my_service_worker_failing_to_register) if you are having problems getting your code to do anything.


### PR DESCRIPTION
http creates a security issue. https allows the service worker to register.  https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#Why_is_my_service_worker_failing_to_register

ps: maybe be a good opportunity to add the example link in github repo homelink