### PR TITLE
modernize service worker example

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/app.js
+++ b/app.js
@@ -1,74 +1,48 @@
-// register service worker
+import { Gallery } from "./image-list.js";
 
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw-test/sw.js', { scope: '/sw-test/' }).then(function(reg) {
-
-    if(reg.installing) {
-      console.log('Service worker installing');
-    } else if(reg.waiting) {
-      console.log('Service worker installed');
-    } else if(reg.active) {
-      console.log('Service worker active');
+const registerServiceWorker = async () => {
+  const registration = await navigator.serviceWorker.register(
+    "/sw-test/sw.js",
+    {
+      scope: "/sw-test/",
     }
-
-  }).catch(function(error) {
-    // registration failed
-    console.log('Registration failed with ' + error);
-  });
-}
-
-// function for loading each image via XHR
-
-function imgLoad(imgJSON) {
-  // return a promise for an image loading
-  return new Promise(function(resolve, reject) {
-    var request = new XMLHttpRequest();
-    request.open('GET', imgJSON.url);
-    request.responseType = 'blob';
-
-    request.onload = function() {
-      if (request.status == 200) {
-        var arrayResponse = [];
-        arrayResponse[0] = request.response;
-        arrayResponse[1] = imgJSON;
-        resolve(arrayResponse);
-      } else {
-        reject(Error('Image didn\'t load successfully; error code:' + request.statusText));
-      }
-    };
-
-    request.onerror = function() {
-      reject(Error('There was a network error.'));
-    };
-
-    // Send the request
-    request.send();
-  });
-}
-
-var imgSection = document.querySelector('section');
-
-window.onload = function() {
-
-  // load each set of image, alt text, name and caption
-  for(var i = 0; i<=Gallery.images.length-1; i++) {
-    imgLoad(Gallery.images[i]).then(function(arrayResponse) {
-
-      var myImage = document.createElement('img');
-      var myFigure = document.createElement('figure');
-      var myCaption = document.createElement('caption');
-      var imageURL = window.URL.createObjectURL(arrayResponse[0]);
-
-      myImage.src = imageURL;
-      myImage.setAttribute('alt', arrayResponse[1].alt);
-      myCaption.innerHTML = '<strong>' + arrayResponse[1].name + '</strong>: Taken by ' + arrayResponse[1].credit;
-
-      imgSection.appendChild(myFigure);
-      myFigure.appendChild(myImage);
-      myFigure.appendChild(myCaption);
-
-    }, function(Error) {
-      console.log(Error);
-    });
+  );
+  if (registration.installing) {
+    console.log("Service worker installing");
+  } else if (registration.waiting) {
+    console.log("Service worker installed");
+  } else if (registration.active) {
+    console.log("Service worker active");
   }
+};
+
+const imgSection = document.querySelector("section");
+
+const createGalleryFigure = (galleryImage) => {
+  const myImage = document.createElement("img");
+  const myCaption = document.createElement("caption");
+  const myFigure = document.createElement("figure");
+  myCaption.innerHTML =
+    "<strong>" +
+    galleryImage.name +
+    "</strong>: Taken by " +
+    galleryImage.credit;
+  myImage.src = galleryImage.url;
+  myImage.setAttribute("alt", galleryImage.alt);
+  myImage.onerror = (error) => console.log("image failed to load", error);
+  myFigure.append(myImage, myCaption);
+  return myFigure;
+};
+
+window.onload = async () => {
+  if ("serviceWorker" in navigator) {
+    try {
+      await registerServiceWorker();
+    } catch (error) {
+      // registration failed
+      console.log("Registration failed with " + error);
+      return;
+    }
+  }
+  imgSection.append(...Gallery.images.map(createGalleryFigure));
 };

--- a/app.js
+++ b/app.js
@@ -28,7 +28,9 @@ const getImageBlob = async (url) => {
   const imageResponse = await fetch(url);
   if (!imageResponse.ok) {
     throw new Error(
-      `Image didn't load successfully; error code: ${imageResponse.statusText}`
+      `Image didn't load successfully; error code: ${
+        imageResponse.statusText || imageResponse.status
+      }`
     );
   }
   return imageResponse.blob();

--- a/app.js
+++ b/app.js
@@ -33,11 +33,7 @@ const createGalleryFigure = async (galleryImage) => {
   const myImage = document.createElement('img');
   const myCaption = document.createElement('caption');
   const myFigure = document.createElement('figure');
-  myCaption.innerHTML =
-    '<strong>' +
-    galleryImage.name +
-    '</strong>: Taken by ' +
-    galleryImage.credit;
+  myCaption.textContent = `${galleryImage.name}: Taken by ${galleryImage.credit}`;
   myImage.src = window.URL.createObjectURL(imageBlob);
   myImage.setAttribute('alt', galleryImage.alt);
   myFigure.append(myImage, myCaption);

--- a/app.js
+++ b/app.js
@@ -1,22 +1,22 @@
-import { Gallery } from "./image-list.js";
+import { Gallery } from './image-list.js';
 
 const registerServiceWorker = async () => {
   const registration = await navigator.serviceWorker.register(
-    "/sw-test/sw.js",
+    '/sw-test/sw.js',
     {
-      scope: "/sw-test/",
+      scope: '/sw-test/',
     }
   );
   if (registration.installing) {
-    console.log("Service worker installing");
+    console.log('Service worker installing');
   } else if (registration.waiting) {
-    console.log("Service worker installed");
+    console.log('Service worker installed');
   } else if (registration.active) {
-    console.log("Service worker active");
+    console.log('Service worker active');
   }
 };
 
-const imgSection = document.querySelector("section");
+const imgSection = document.querySelector('section');
 
 const getImageBlob = async (url) => {
   const imageResponse = await fetch(url);
@@ -30,26 +30,26 @@ const getImageBlob = async (url) => {
 
 const createGalleryFigure = async (galleryImage) => {
   const imageBlob = await getImageBlob(galleryImage.url);
-  const myImage = document.createElement("img");
-  const myCaption = document.createElement("caption");
-  const myFigure = document.createElement("figure");
+  const myImage = document.createElement('img');
+  const myCaption = document.createElement('caption');
+  const myFigure = document.createElement('figure');
   myCaption.innerHTML =
-    "<strong>" +
+    '<strong>' +
     galleryImage.name +
-    "</strong>: Taken by " +
+    '</strong>: Taken by ' +
     galleryImage.credit;
   myImage.src = window.URL.createObjectURL(imageBlob);
-  myImage.setAttribute("alt", galleryImage.alt);
+  myImage.setAttribute('alt', galleryImage.alt);
   myFigure.append(myImage, myCaption);
   imgSection.append(myFigure);
 };
 
 window.onload = async () => {
-  if ("serviceWorker" in navigator) {
+  if ('serviceWorker' in navigator) {
     try {
       await registerServiceWorker();
     } catch (error) {
-      console.log("Registration failed with " + error);
+      console.log('Registration failed with ' + error);
       return;
     }
   }

--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ const createGalleryFigure = (galleryImage) => {
     galleryImage.credit;
   myImage.src = galleryImage.url;
   myImage.setAttribute("alt", galleryImage.alt);
-  myImage.onerror = (error) => console.log("image failed to load", error);
+  myImage.onerror = () => console.log(`image failed to load: ${myImage.src}`);
   myFigure.append(myImage, myCaption);
   return myFigure;
 };

--- a/app.js
+++ b/app.js
@@ -18,7 +18,18 @@ const registerServiceWorker = async () => {
 
 const imgSection = document.querySelector("section");
 
-const createGalleryFigure = (galleryImage) => {
+const getImageBlob = async (url) => {
+  const imageResponse = await fetch(url);
+  if (!imageResponse.ok) {
+    throw new Error(
+      "Image didn't load successfully; error code:" + imageResponse.statusText
+    );
+  }
+  return imageResponse.blob();
+};
+
+const createGalleryFigure = async (galleryImage) => {
+  const imageBlob = await getImageBlob(galleryImage.url);
   const myImage = document.createElement("img");
   const myCaption = document.createElement("caption");
   const myFigure = document.createElement("figure");
@@ -27,11 +38,10 @@ const createGalleryFigure = (galleryImage) => {
     galleryImage.name +
     "</strong>: Taken by " +
     galleryImage.credit;
-  myImage.src = galleryImage.url;
+  myImage.src = window.URL.createObjectURL(imageBlob);
   myImage.setAttribute("alt", galleryImage.alt);
-  myImage.onerror = () => console.log(`image failed to load: ${myImage.src}`);
   myFigure.append(myImage, myCaption);
-  return myFigure;
+  imgSection.append(myFigure);
 };
 
 window.onload = async () => {
@@ -43,5 +53,5 @@ window.onload = async () => {
       return;
     }
   }
-  imgSection.append(...Gallery.images.map(createGalleryFigure));
+  await Promise.allSettled(Gallery.images.map(createGalleryFigure));
 };

--- a/app.js
+++ b/app.js
@@ -39,7 +39,6 @@ window.onload = async () => {
     try {
       await registerServiceWorker();
     } catch (error) {
-      // registration failed
       console.log("Registration failed with " + error);
       return;
     }

--- a/app.js
+++ b/app.js
@@ -1,18 +1,24 @@
 import { Gallery } from './image-list.js';
 
 const registerServiceWorker = async () => {
-  const registration = await navigator.serviceWorker.register(
-    '/sw-test/sw.js',
-    {
-      scope: '/sw-test/',
+  if ('serviceWorker' in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.register(
+        '/sw-test/sw.js',
+        {
+          scope: '/sw-test/',
+        }
+      );
+      if (registration.installing) {
+        console.log('Service worker installing');
+      } else if (registration.waiting) {
+        console.log('Service worker installed');
+      } else if (registration.active) {
+        console.log('Service worker active');
+      }
+    } catch (error) {
+      console.error(`Registration failed with ${error}`);
     }
-  );
-  if (registration.installing) {
-    console.log('Service worker installing');
-  } else if (registration.waiting) {
-    console.log('Service worker installed');
-  } else if (registration.active) {
-    console.log('Service worker active');
   }
 };
 
@@ -40,14 +46,5 @@ const createGalleryFigure = async (galleryImage) => {
   imgSection.append(myFigure);
 };
 
-window.onload = async () => {
-  if ('serviceWorker' in navigator) {
-    try {
-      await registerServiceWorker();
-    } catch (error) {
-      console.log('Registration failed with ' + error);
-      return;
-    }
-  }
-  await Promise.allSettled(Gallery.images.map(createGalleryFigure));
-};
+registerServiceWorker();
+Gallery.images.map(createGalleryFigure);

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ const getImageBlob = async (url) => {
   const imageResponse = await fetch(url);
   if (!imageResponse.ok) {
     throw new Error(
-      "Image didn't load successfully; error code:" + imageResponse.statusText
+      `Image didn't load successfully; error code: ${imageResponse.statusText}`
     );
   }
   return imageResponse.blob();

--- a/app.js
+++ b/app.js
@@ -35,15 +35,19 @@ const getImageBlob = async (url) => {
 };
 
 const createGalleryFigure = async (galleryImage) => {
-  const imageBlob = await getImageBlob(galleryImage.url);
-  const myImage = document.createElement('img');
-  const myCaption = document.createElement('caption');
-  const myFigure = document.createElement('figure');
-  myCaption.textContent = `${galleryImage.name}: Taken by ${galleryImage.credit}`;
-  myImage.src = window.URL.createObjectURL(imageBlob);
-  myImage.setAttribute('alt', galleryImage.alt);
-  myFigure.append(myImage, myCaption);
-  imgSection.append(myFigure);
+  try {
+    const imageBlob = await getImageBlob(galleryImage.url);
+    const myImage = document.createElement('img');
+    const myCaption = document.createElement('caption');
+    const myFigure = document.createElement('figure');
+    myCaption.textContent = `${galleryImage.name}: Taken by ${galleryImage.credit}`;
+    myImage.src = window.URL.createObjectURL(imageBlob);
+    myImage.setAttribute('alt', galleryImage.alt);
+    myFigure.append(myImage, myCaption);
+    imgSection.append(myFigure);
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 registerServiceWorker();

--- a/image-list.js
+++ b/image-list.js
@@ -1,26 +1,29 @@
-var Path = 'gallery/';
+export const Path = "gallery/";
 
-var Gallery = { 'images' : [
-      
-  {
-    'name'  : 'Darth Vader',
-    'alt' : 'A Black Clad warrior lego toy',
-    'url': 'gallery/myLittleVader.jpg',
-    'credit': '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.'
-  },
+export const Gallery = {
+  images: [
+    {
+      name: "Darth Vader",
+      alt: "A Black Clad warrior lego toy",
+      url: "gallery/myLittleVader.jpg",
+      credit:
+        '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.',
+    },
 
-  {
-    'name'  : 'Snow Troopers',
-    'alt' : 'Two lego solders in white outfits walking across an icy plain',
-    'url': 'gallery/snowTroopers.jpg',
-    'credit': '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.'
-  },
+    {
+      name: "Snow Troopers",
+      alt: "Two lego solders in white outfits walking across an icy plain",
+      url: "gallery/snowTroopers.jpg",
+      credit:
+        '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.',
+    },
 
-  {
-    'name'  : 'Bounty Hunters',
-    'alt' : 'A group of bounty hunters meeting, aliens and humans in costumes.',
-    'url': 'gallery/bountyHunters.jpg',
-    'credit': '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.'
-  },
-  
-]};
+    {
+      name: "Bounty Hunters",
+      alt: "A group of bounty hunters meeting, aliens and humans in costumes.",
+      url: "gallery/bountyHunters.jpg",
+      credit:
+        '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.',
+    },
+  ],
+};

--- a/image-list.js
+++ b/image-list.js
@@ -1,27 +1,27 @@
-export const Path = "gallery/";
+export const Path = 'gallery/';
 
 export const Gallery = {
   images: [
     {
-      name: "Darth Vader",
-      alt: "A Black Clad warrior lego toy",
-      url: "gallery/myLittleVader.jpg",
+      name: 'Darth Vader',
+      alt: 'A Black Clad warrior lego toy',
+      url: 'gallery/myLittleVader.jpg',
       credit:
         '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.',
     },
 
     {
-      name: "Snow Troopers",
-      alt: "Two lego solders in white outfits walking across an icy plain",
-      url: "gallery/snowTroopers.jpg",
+      name: 'Snow Troopers',
+      alt: 'Two lego solders in white outfits walking across an icy plain',
+      url: 'gallery/snowTroopers.jpg',
       credit:
         '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.',
     },
 
     {
-      name: "Bounty Hunters",
-      alt: "A group of bounty hunters meeting, aliens and humans in costumes.",
-      url: "gallery/bountyHunters.jpg",
+      name: 'Bounty Hunters',
+      alt: 'A group of bounty hunters meeting, aliens and humans in costumes.',
+      url: 'gallery/bountyHunters.jpg',
       credit:
         '<a href="https://www.flickr.com/photos/legofenris/">legOfenris</a>, published under a <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/">Attribution-NonCommercial-NoDerivs 2.0 Generic</a> license.',
     },

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width" />
 
     <title>Service worker demo</title>
 
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -18,7 +18,6 @@
 
     <section></section>
 
-    <script src="image-list.js"></script>
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   font-size: 10px;
@@ -24,7 +25,7 @@ figure {
 }
 
 img {
-  width: 100%;	
+  width: 100%;
   box-shadow: 2px 2px 1px black;
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,41 +1,70 @@
-self.addEventListener('install', function(event) {
+const addResourcesToCache = async (resources) => {
+  const cache = await caches.open("v1");
+  await cache.addAll(resources);
+};
+
+const putInCache = async (request, response) => {
+  const cache = await caches.open("v1");
+  await cache.put(request, response);
+};
+
+const networkOnly = async (request) => {
+  return fetch(request);
+};
+
+const cacheFirst = async (request) => {
+  const responseFromCache = await caches.match(request);
+  if (responseFromCache) {
+    return responseFromCache;
+  }
+  const responseFromNetwork = await fetch(request);
+  console.log(responseFromNetwork);
+  if (!responseFromNetwork.ok) {
+    return responseFromNetwork;
+  }
+  // response may be used only once
+  // we need to save clone to put one copy in cache
+  // and serve second one
+  await putInCache(responseFromNetwork.clone());
+  return responseFromNetwork;
+};
+
+const fallback = (request) => {
+  return caches.match("./sw-test/gallery/myLittleVader.jpg");
+};
+
+const cacheFirstWithFallback = async (request) => {
+  try {
+    return await cacheFirst(request);
+  } catch (error) {
+    console.log(`failed to load ${request.url}`, error);
+    try {
+      return await fallback(request);
+    } catch (error) {
+      return new Response("Network error happened", {
+        status: 408,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+  }
+};
+
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open('v1').then(function(cache) {
-      return cache.addAll([
-        '/sw-test/',
-        '/sw-test/index.html',
-        '/sw-test/style.css',
-        '/sw-test/app.js',
-        '/sw-test/image-list.js',
-        '/sw-test/star-wars-logo.jpg',
-        '/sw-test/gallery/bountyHunters.jpg',
-        '/sw-test/gallery/myLittleVader.jpg',
-        '/sw-test/gallery/snowTroopers.jpg'
-      ]);
-    })
+    addResourcesToCache([
+      "/sw-test/",
+      "/sw-test/index.html",
+      "/sw-test/style.css",
+      "/sw-test/app.js",
+      "/sw-test/image-list.js",
+      "/sw-test/star-wars-logo.jpg",
+      "/sw-test/gallery/bountyHunters.jpg",
+      "/sw-test/gallery/myLittleVader.jpg",
+      "/sw-test/gallery/snowTroopers.jpg",
+    ])
   );
 });
 
-self.addEventListener('fetch', function(event) {
-  event.respondWith(caches.match(event.request).then(function(response) {
-    // caches.match() always resolves
-    // but in case of success response will have value
-    if (response !== undefined) {
-      return response;
-    } else {
-      return fetch(event.request).then(function (response) {
-        // response may be used only once
-        // we need to save clone to put one copy in cache
-        // and serve second one
-        let responseClone = response.clone();
-        
-        caches.open('v1').then(function (cache) {
-          cache.put(event.request, responseClone);
-        });
-        return response;
-      }).catch(function () {
-        return caches.match('/sw-test/gallery/myLittleVader.jpg');
-      });
-    }
-  }));
+self.addEventListener("fetch", (event) => {
+  event.respondWith(cacheFirstWithFallback(event.request));
 });

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,10 @@
 const addResourcesToCache = async (resources) => {
-  const cache = await caches.open("v1");
+  const cache = await caches.open('v1');
   await cache.addAll(resources);
 };
 
 const putInCache = async (request, response) => {
-  const cache = await caches.open("v1");
+  const cache = await caches.open('v1');
   await cache.put(request, response);
 };
 
@@ -24,9 +24,9 @@ const cacheFirst = async ({ request, fallbackUrl }) => {
     // when the even fallback response is not available,
     // there is nothing we can do, but we must always
     // return a Response object
-    return new Response("Network error happened", {
+    return new Response('Network error happened', {
       status: 408,
-      headers: { "Content-Type": "text/plain" },
+      headers: { 'Content-Type': 'text/plain' },
     });
   }
   // response may be used only once
@@ -36,27 +36,27 @@ const cacheFirst = async ({ request, fallbackUrl }) => {
   return responseFromNetwork;
 };
 
-self.addEventListener("install", (event) => {
+self.addEventListener('install', (event) => {
   event.waitUntil(
     addResourcesToCache([
-      "/sw-test/",
-      "/sw-test/index.html",
-      "/sw-test/style.css",
-      "/sw-test/app.js",
-      "/sw-test/image-list.js",
-      "/sw-test/star-wars-logo.jpg",
-      "/sw-test/gallery/bountyHunters.jpg",
-      "/sw-test/gallery/myLittleVader.jpg",
-      "/sw-test/gallery/snowTroopers.jpg",
+      '/sw-test/',
+      '/sw-test/index.html',
+      '/sw-test/style.css',
+      '/sw-test/app.js',
+      '/sw-test/image-list.js',
+      '/sw-test/star-wars-logo.jpg',
+      '/sw-test/gallery/bountyHunters.jpg',
+      '/sw-test/gallery/myLittleVader.jpg',
+      '/sw-test/gallery/snowTroopers.jpg',
     ])
   );
 });
 
-self.addEventListener("fetch", (event) => {
+self.addEventListener('fetch', (event) => {
   event.respondWith(
     cacheFirst({
       request: event.request,
-      fallbackUrl: "/sw-test/gallery/myLittleVader.jpg",
+      fallbackUrl: '/sw-test/gallery/myLittleVader.jpg',
     })
   );
 });

--- a/sw.js
+++ b/sw.js
@@ -23,7 +23,7 @@ const cacheFirst = async ({ request, fallbackUrl }) => {
     }
     // when the even fallback response is not available,
     // there is nothing we can do, but we must always
-    // return a response
+    // return a Response object
     return new Response("Network error happened", {
       status: 408,
       headers: { "Content-Type": "text/plain" },

--- a/sw.js
+++ b/sw.js
@@ -15,9 +15,13 @@ const cacheFirst = async ({ request, fallbackUrl }) => {
     return responseFromCache;
   }
   // Next try to get the resource from the network
-  let responseFromNetwork;
   try {
-    responseFromNetwork = await fetch(request);
+    const responseFromNetwork = await fetch(request);
+    // response may be used only once
+    // we need to save clone to put one copy in cache
+    // and serve second one
+    putInCache(request, responseFromNetwork.clone());
+    return responseFromNetwork;
   } catch (error) {
     const fallbackResponse = await caches.match(fallbackUrl);
     if (fallbackResponse) {
@@ -31,11 +35,6 @@ const cacheFirst = async ({ request, fallbackUrl }) => {
       headers: { 'Content-Type': 'text/plain' },
     });
   }
-  // response may be used only once
-  // we need to save clone to put one copy in cache
-  // and serve second one
-  putInCache(request, responseFromNetwork.clone());
-  return responseFromNetwork;
 };
 
 self.addEventListener('install', (event) => {

--- a/sw.js
+++ b/sw.js
@@ -9,10 +9,12 @@ const putInCache = async (request, response) => {
 };
 
 const cacheFirst = async ({ request, fallbackUrl }) => {
+  // First try to get the resource from the cache
   const responseFromCache = await caches.match(request);
   if (responseFromCache) {
     return responseFromCache;
   }
+  // Next try to get the resource from the network
   let responseFromNetwork;
   try {
     responseFromNetwork = await fetch(request);
@@ -21,7 +23,7 @@ const cacheFirst = async ({ request, fallbackUrl }) => {
     if (fallbackResponse) {
       return fallbackResponse;
     }
-    // when the even fallback response is not available,
+    // when even the fallback response is not available,
     // there is nothing we can do, but we must always
     // return a Response object
     return new Response('Network error happened', {

--- a/sw.js
+++ b/sw.js
@@ -20,7 +20,13 @@ const cacheFirst = async (request) => {
     const fallBackResponse = await caches.match(
       "/sw-test/gallery/myLittleVader.jpg"
     );
-    return fallBackResponse;
+    if (fallBackResponse) {
+      return fallBackResponse;
+    }
+    return new Response("Network error happened", {
+      status: 408,
+      headers: { "Content-Type": "text/plain" },
+    });
   }
   // response may be used only once
   // we need to save clone to put one copy in cache

--- a/sw.js
+++ b/sw.js
@@ -25,7 +25,7 @@ const cacheFirst = async (request) => {
   // response may be used only once
   // we need to save clone to put one copy in cache
   // and serve second one
-  await putInCache(responseFromNetwork.clone());
+  await putInCache(request, responseFromNetwork.clone());
   return responseFromNetwork;
 };
 
@@ -38,14 +38,14 @@ const cacheFirstWithFallback = async (request) => {
     return await cacheFirst(request);
   } catch (error) {
     console.log(`failed to load ${request.url}`, error);
-    try {
-      return await fallback(request);
-    } catch (error) {
-      return new Response("Network error happened", {
-        status: 408,
-        headers: { "Content-Type": "text/plain" },
-      });
+    const response = await fallback(request);
+    if (response) {
+      return response;
     }
+    return new Response("Network error happened", {
+      status: 408,
+      headers: { "Content-Type": "text/plain" },
+    });
   }
 };
 


### PR DESCRIPTION
Tries to modernize the service worker example by
- replacing `Promise.then` with `async` / `await`
- replacing `XMLHttpRequest` with `fetch`
- replacing `var` with `const`

Not sure if this is a bit too over-engineered at some places, however in my testing, everything still worked as expected.